### PR TITLE
Add support for colon symbol in html attributes and support for slim/slimleex extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "languages": [{
             "id": "slime",
             "aliases": ["Slime", "slime"],
-            "extensions": [".slime"],
+            "extensions": [".slime", ".slim", ".slimleex"],
             "configuration": "./language-configuration.json"
         }],
         "snippets": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "slime",
     "displayName": "Slime",
     "description": "Slime Language",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "xolan",
     "repository": {
         "type": "git",

--- a/syntaxes/slime.tmLanguage
+++ b/syntaxes/slime.tmLanguage
@@ -529,7 +529,7 @@
 		<key>normal-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w.#_-]+=)</string>
+			<string>([\w:.#_-]+=)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -559,7 +559,7 @@
 		<key>normal-inline-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w.#_-]+)</string>
+			<string>([\w.#_-:]+)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>

--- a/test.slime
+++ b/test.slime
@@ -11,3 +11,5 @@ html
       ul
         = Enum.map [1, 2], fn x ->
           li = x
+          li(x-on:click.stop.prevent="toggle" x-on:click.away="close")
+            | Slime supports Vue/AlpineJS syntax!

--- a/test.slime
+++ b/test.slime
@@ -10,6 +10,6 @@ html
     #id.class
       ul
         = Enum.map [1, 2], fn x ->
-          li = x
-          li(x-on:click.stop.prevent="toggle" x-on:click.away="close")
+          li:tag = x
+          li x-on:click.stop.prevent="toggle" x-on:click.away="close"
             | Slime supports Vue/AlpineJS syntax!


### PR DESCRIPTION
- Support for `.slim` file extension
- Support for `.slimleex` file extension (slim with LiveView)
- Support for Vue/AlpineJS style attribute names for syntax highlighting that contain a `:` character (for ex: `a(href="#" x-on:click=....`)
- Bumped version number to `1.0.3`